### PR TITLE
Create a basic frontend interface.

### DIFF
--- a/front/dashboard/index.html
+++ b/front/dashboard/index.html
@@ -1,0 +1,10 @@
+<DOCTYPE html>
+<html>
+<head>
+<title>Kool Monkey</title>
+</head>
+<body>
+<h1>Kool Monkey</h1>
+</body>
+</html>
+

--- a/front/www/index.html
+++ b/front/www/index.html
@@ -1,0 +1,10 @@
+<DOCTYPE html>
+<html>
+<head>
+<title>Kool Monkey</title>
+</head>
+<body>
+<h1>Kool Monkey</h1>
+</body>
+</html>
+

--- a/rpm/kool-server.spec
+++ b/rpm/kool-server.spec
@@ -27,8 +27,12 @@ provides the server part of Kool monkey.
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_sysconfdir}
 mkdir -p %{buildroot}%{_datadir}
+mkdir -p %{buildroot}%{_exec_prefix}/www
+mkdir -p %{buildroot}%{_exec_prefix}/dashboard
 %{__install} -Dp -m 0755 bin/kool-server %{buildroot}%{_bindir}/kool-server
 %{__install} -Dp -m 0644 scripts/db/*.sql %{buildroot}%{_datadir}
+%{__install} -Dp -m 0644 front/www/* %{buildroot}%{_exec_prefix}/www
+%{__install} -Dp -m 0644 front/dashboard/* %{buildroot}%{_exec_prefix}/dashboard
 %{__install} -Dp -m 0755 scripts/init/kool-server %{buildroot}%{_sysconfdir}/init.d/kool-server
 %{__install} -Dp -m 0755 systemd/kool-server.service %{buildroot}%{_systemddir}/kool-server.service
 %{__install} -Dp -m 0644 conf/kool-server.conf %{buildroot}%{_sysconfdir}/kool-server.conf
@@ -72,6 +76,8 @@ su postgres -c "/usr/bin/dropdb ${port} --if-exists monkey"
 %files
 %defattr(-, root, root, 0755)
 %{_bindir}/kool-server
+%{_exec_prefix}/www
+%{_exec_prefix}/dashboard
 %{_datadir}/create_db.sql
 %{_datadir}/upgrade_db.sql
 %{_datadir}/create_roles.sql

--- a/src/kool-server/kool-server.go
+++ b/src/kool-server/kool-server.go
@@ -119,7 +119,17 @@ func alive(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	fmt.Println("Starting server!")
+	fmt.Println("Starting static dashboard server at port 3002")
+	go func() {
+		panic(http.ListenAndServe(":3002", http.FileServer(http.Dir("/opt/kool_monkey/dashboard"))))
+	}()
+
+	fmt.Println("Starting static www server at port 3001")
+	go func() {
+		panic(http.ListenAndServe(":3001", http.FileServer(http.Dir("/opt/kool_monkey/www"))))
+	}()
+
+	fmt.Println("Starting api server at port 3000")
 
 	err := connectToDb()
 	if err != nil {


### PR DESCRIPTION
Frontend web service is also supported by kool-server.
Before it inizialize the main api, it spawns two file servers,
one for 'www' domain and the other for the 'dashboard' domain.
